### PR TITLE
Update to new io.stdin.supportsAnsiEscapes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.1
+
+* Updated `LocalPlatform` to use new `dart.io` API for ansi color support queries
+* Bumped minimum Dart SDK version to 1.23.0-dev.10.0
+
 ### 1.1.0
 
 * Added `ansiSupported`

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' as io show Platform;
+import 'dart:io' as io show Platform, stdin;
 
 import 'platform.dart';
 
@@ -48,5 +48,5 @@ class LocalPlatform extends Platform {
   String get version => io.Platform.version;
 
   @override
-  bool get ansiSupported => io.Platform.ansiSupported;
+  bool get ansiSupported => io.stdin.supportsAnsiEscapes;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,4 @@ dev_dependencies:
   test: ^0.12.10
 
 environment:
-  sdk: '>=1.23.0-dev.9.0 <2.0.0'
+  sdk: '>=1.23.0-dev.10.0 <2.0.0'


### PR DESCRIPTION
See: https://github.com/flutter/flutter/pull/9051

@tvolkert @goderbauer 