### PR TITLE
[null-safety] migrate platform to null-safe dart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 sudo: false
 dart:
-  - stable
   - dev
 install:
   - gem install coveralls-lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ### 3.0.0-nullsafety
 
 * Migrate package to null-safe dart.
-* Most parameters of the `FakePlatform` constructor are now required to match
-  non-nullability of `Platform` APIs.
 
 ### 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.0.0-nullsafety
+
+* Migrate package to null-safe dart.
+* Most parameters of the `FakePlatform` constructor are now required to match
+  non-nullability of `Platform` APIs.
+
 ### 2.2.1
 
 * Add `operatingSystemVersion`

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,6 @@
 analyzer:
-  language:
-    enableStrictCallChecks: true
-    enableSuperMixins: true
-  strong-mode: true
+  enable-experiment:
+    - non-nullable
   errors:
     # Allow having TODOs in the code
     todo: ignore
@@ -40,7 +38,6 @@ linter:
     - await_only_futures
     - camel_case_types
     - constant_identifier_names
-    - control_flow_in_finally
     - empty_constructor_bodies
     - implementation_imports
     - library_names
@@ -56,11 +53,9 @@ linter:
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
-    - super_goes_last
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
-    - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters
 
     # === pub rules ===

--- a/dev/travis.sh
+++ b/dev/travis.sh
@@ -27,4 +27,4 @@ echo "PASSED"
 set -e
 
 # Run the tests.
-pub run test
+pub run --enable-experiment=non-nullable test

--- a/dev/travis.sh
+++ b/dev/travis.sh
@@ -15,7 +15,7 @@ echo "PASSED"
 
 # Make sure we pass the analyzer
 echo "Checking dartanalyzer..."
-fails_analyzer="$(find lib test dev -name "*.dart" | xargs dartanalyzer --options .analysis_options)"
+fails_analyzer="$(find lib test dev -name "*.dart" | xargs dartanalyzer --options analysis_options.yaml)"
 if [[ "$fails_analyzer" == *"[error]"* ]]; then
   echo "FAILED"
   echo "$fails_analyzer"

--- a/lib/platform.dart
+++ b/lib/platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.10
 /// Core interfaces & classes.
 export 'src/interface/local_platform.dart';
 export 'src/interface/platform.dart';

--- a/lib/platform.dart
+++ b/lib/platform.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
 /// Core interfaces & classes.
 export 'src/interface/local_platform.dart';
 export 'src/interface/platform.dart';

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -43,7 +43,8 @@ class LocalPlatform extends Platform {
   List<String> get executableArguments => io.Platform.executableArguments;
 
   @override
-  String? get packageRoot => io.Platform.packageRoot; // ignore: deprecated_member_use
+  String? get packageRoot =>
+      io.Platform.packageRoot; // ignore: deprecated_member_use
 
   @override
   String? get packageConfig => io.Platform.packageConfig;

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.10
 import 'dart:io' as io show Platform, stdin, stdout;
 
 import 'platform.dart';

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
 import 'dart:io' as io show Platform, stdin, stdout;
 
 import 'platform.dart';
@@ -42,10 +43,10 @@ class LocalPlatform extends Platform {
   List<String> get executableArguments => io.Platform.executableArguments;
 
   @override
-  String get packageRoot => io.Platform.packageRoot;
+  String? get packageRoot => io.Platform.packageRoot; // ignore: deprecated_member_use
 
   @override
-  String get packageConfig => io.Platform.packageConfig;
+  String? get packageConfig => io.Platform.packageConfig;
 
   @override
   String get version => io.Platform.version;

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.10
 import 'dart:convert';
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
 import 'dart:convert';
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using
@@ -101,14 +102,15 @@ abstract class Platform {
   /// Dart packages are looked up.
   ///
   /// If there is no `--package-root` flag, `null` is returned.
-  String get packageRoot;
+  @deprecated
+  String? get packageRoot;
 
   /// The value of the `--packages` flag passed to the executable
   /// used to run the script in this isolate. This is the configuration which
   /// specifies how Dart packages are looked up.
   ///
   /// If there is no `--packages` flag, `null` is returned.
-  String get packageConfig;
+  String? get packageConfig;
 
   /// The version of the current Dart runtime.
   ///
@@ -139,7 +141,7 @@ abstract class Platform {
       'resolvedExecutable': resolvedExecutable,
       'script': script.toString(),
       'executableArguments': executableArguments,
-      'packageRoot': packageRoot,
+      'packageRoot': packageRoot, // ignore: deprecated_member_use_from_same_package
       'packageConfig': packageConfig,
       'version': version,
       'stdinSupportsAnsi': stdinSupportsAnsi,

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -141,7 +141,8 @@ abstract class Platform {
       'resolvedExecutable': resolvedExecutable,
       'script': script.toString(),
       'executableArguments': executableArguments,
-      'packageRoot': packageRoot, // ignore: deprecated_member_use_from_same_package
+      'packageRoot':
+          packageRoot, // ignore: deprecated_member_use_from_same_package
       'packageConfig': packageConfig,
       'version': version,
       'stdinSupportsAnsi': stdinSupportsAnsi,

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -12,46 +12,60 @@ class FakePlatform extends Platform {
   /// Creates a new [FakePlatform] with the specified properties.
   ///
   /// Unspecified properties will *not* be assigned default values (they will
-  /// remain `null`).
+  /// remain `null`). If an unset non-null value is read, a [StateError] will
+  /// be thrown instead of returnin `null`.
   FakePlatform({
-    required this.numberOfProcessors,
-    required this.pathSeparator,
-    required this.operatingSystem,
-    required this.operatingSystemVersion,
-    required this.localHostname,
-    required this.environment,
-    required this.executable,
-    required this.resolvedExecutable,
-    required this.script,
-    required this.executableArguments,
+    int? numberOfProcessors,
+    String? pathSeparator,
+    String? operatingSystem,
+    String? operatingSystemVersion,
+    String? localHostname,
+    Map<String, String>? environment,
+    String? executable,
+    String? resolvedExecutable,
+    Uri? script,
+    List<String>? executableArguments,
     this.packageRoot,
     this.packageConfig,
-    required this.version,
-    required this.stdinSupportsAnsi,
-    required this.stdoutSupportsAnsi,
-    required this.localeName,
-  });
+    String? version,
+    bool? stdinSupportsAnsi,
+    bool? stdoutSupportsAnsi,
+    String? localeName,
+  })  : _numberOfProcessors = numberOfProcessors,
+        _pathSeparator = pathSeparator,
+        _operatingSystem = operatingSystem,
+        _operatingSystemVersion = operatingSystemVersion,
+        _localHostname = localHostname,
+        _environment = environment,
+        _executable = executable,
+        _resolvedExecutable = resolvedExecutable,
+        _script = script,
+        _executableArguments = executableArguments,
+        _version = version,
+        _stdinSupportsAnsi = stdinSupportsAnsi,
+        _stdoutSupportsAnsi = stdoutSupportsAnsi,
+        _localeName = localeName;
 
   /// Creates a new [FakePlatform] with properties whose initial values mirror
   /// the specified [platform].
   FakePlatform.fromPlatform(Platform platform)
-      : numberOfProcessors = platform.numberOfProcessors,
-        pathSeparator = platform.pathSeparator,
-        operatingSystem = platform.operatingSystem,
-        operatingSystemVersion = platform.operatingSystemVersion,
-        localHostname = platform.localHostname,
-        environment = Map<String, String>.from(platform.environment),
-        executable = platform.executable,
-        resolvedExecutable = platform.resolvedExecutable,
-        script = platform.script,
-        executableArguments = List<String>.from(platform.executableArguments),
+      : _numberOfProcessors = platform.numberOfProcessors,
+        _pathSeparator = platform.pathSeparator,
+        _operatingSystem = platform.operatingSystem,
+        _operatingSystemVersion = platform.operatingSystemVersion,
+        _localHostname = platform.localHostname,
+        _environment = Map<String, String>.from(platform.environment),
+        _executable = platform.executable,
+        _resolvedExecutable = platform.resolvedExecutable,
+        _script = platform.script,
+        _executableArguments = List<String>.from(platform.executableArguments),
         packageRoot = platform
             .packageRoot, // ignore: deprecated_member_use_from_same_package
         packageConfig = platform.packageConfig,
-        version = platform.version,
-        stdinSupportsAnsi = platform.stdinSupportsAnsi,
-        stdoutSupportsAnsi = platform.stdoutSupportsAnsi,
-        localeName = platform.localeName;
+        _version = platform.version,
+        _stdinSupportsAnsi = platform.stdinSupportsAnsi,
+        _stdoutSupportsAnsi = platform.stdoutSupportsAnsi,
+        _localeName = platform.localeName;
 
   /// Creates a new [FakePlatform] with properties extracted from the encoded
   /// JSON string.
@@ -81,34 +95,44 @@ class FakePlatform extends Platform {
   }
 
   @override
-  int numberOfProcessors;
+  int get numberOfProcessors => _throwIfNull(_numberOfProcessors);
+  int? _numberOfProcessors;
 
   @override
-  String pathSeparator;
+  String get pathSeparator => _throwIfNull(_pathSeparator);
+  String? _pathSeparator;
 
   @override
-  String operatingSystem;
+  String get operatingSystem => _throwIfNull(_operatingSystem);
+  String? _operatingSystem;
 
   @override
-  String operatingSystemVersion;
+  String get operatingSystemVersion => _throwIfNull(_operatingSystemVersion);
+  String? _operatingSystemVersion;
 
   @override
-  String localHostname;
+  String get localHostname => _throwIfNull(_localHostname);
+  String? _localHostname;
 
   @override
-  Map<String, String> environment;
+  Map<String, String> get environment => _throwIfNull(_environment);
+  Map<String, String>? _environment;
 
   @override
-  String executable;
+  String get executable => _throwIfNull(_executable);
+  String? _executable;
 
   @override
-  String resolvedExecutable;
+  String get resolvedExecutable => _throwIfNull(_resolvedExecutable);
+  String? _resolvedExecutable;
 
   @override
-  Uri script;
+  Uri get script => _throwIfNull(_script);
+  Uri? _script;
 
   @override
-  List<String> executableArguments;
+  List<String> get executableArguments => _throwIfNull(_executableArguments);
+  List<String>? _executableArguments;
 
   @override
   String? packageRoot;
@@ -117,14 +141,26 @@ class FakePlatform extends Platform {
   String? packageConfig;
 
   @override
-  String version;
+  String get version => _throwIfNull(_version);
+  String? _version;
 
   @override
-  bool stdinSupportsAnsi;
+  bool get stdinSupportsAnsi => _throwIfNull(_stdinSupportsAnsi);
+  bool? _stdinSupportsAnsi;
 
   @override
-  bool stdoutSupportsAnsi;
+  bool get stdoutSupportsAnsi => _throwIfNull(_stdoutSupportsAnsi);
+  bool? _stdoutSupportsAnsi;
 
   @override
-  String localeName;
+  String get localeName => _throwIfNull(_localeName);
+  String? _localeName;
+
+  T _throwIfNull<T>(T? value) {
+    if (value == null) {
+      throw StateError(
+          'Tried to read property of FakePlatform but it was unset.');
+    }
+    return value;
+  }
 }

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
 import 'dart:convert';
 
 import '../interface/platform.dart';
@@ -13,22 +14,22 @@ class FakePlatform extends Platform {
   /// Unspecified properties will *not* be assigned default values (they will
   /// remain `null`).
   FakePlatform({
-    this.numberOfProcessors,
-    this.pathSeparator,
-    this.operatingSystem,
-    this.operatingSystemVersion,
-    this.localHostname,
-    this.environment,
-    this.executable,
-    this.resolvedExecutable,
-    this.script,
-    this.executableArguments,
+    required this.numberOfProcessors,
+    required this.pathSeparator,
+    required this.operatingSystem,
+    required this.operatingSystemVersion,
+    required this.localHostname,
+    required this.environment,
+    required this.executable,
+    required this.resolvedExecutable,
+    required this.script,
+    required this.executableArguments,
     this.packageRoot,
     this.packageConfig,
-    this.version,
-    this.stdinSupportsAnsi,
-    this.stdoutSupportsAnsi,
-    this.localeName,
+    required this.version,
+    required this.stdinSupportsAnsi,
+    required this.stdoutSupportsAnsi,
+    required this.localeName,
   });
 
   /// Creates a new [FakePlatform] with properties whose initial values mirror
@@ -39,13 +40,13 @@ class FakePlatform extends Platform {
         operatingSystem = platform.operatingSystem,
         operatingSystemVersion = platform.operatingSystemVersion,
         localHostname = platform.localHostname,
-        environment = new Map<String, String>.from(platform.environment),
+        environment = Map<String, String>.from(platform.environment),
         executable = platform.executable,
         resolvedExecutable = platform.resolvedExecutable,
         script = platform.script,
         executableArguments =
-            new List<String>.from(platform.executableArguments),
-        packageRoot = platform.packageRoot,
+            List<String>.from(platform.executableArguments),
+        packageRoot = platform.packageRoot, // ignore: deprecated_member_use_from_same_package
         packageConfig = platform.packageConfig,
         version = platform.version,
         stdinSupportsAnsi = platform.stdinSupportsAnsi,
@@ -110,10 +111,10 @@ class FakePlatform extends Platform {
   List<String> executableArguments;
 
   @override
-  String packageRoot;
+  String? packageRoot;
 
   @override
-  String packageConfig;
+  String? packageConfig;
 
   @override
   String version;

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.10
 import 'dart:convert';
 
 import '../interface/platform.dart';

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -44,9 +44,9 @@ class FakePlatform extends Platform {
         executable = platform.executable,
         resolvedExecutable = platform.resolvedExecutable,
         script = platform.script,
-        executableArguments =
-            List<String>.from(platform.executableArguments),
-        packageRoot = platform.packageRoot, // ignore: deprecated_member_use_from_same_package
+        executableArguments = List<String>.from(platform.executableArguments),
+        packageRoot = platform
+            .packageRoot, // ignore: deprecated_member_use_from_same_package
         packageConfig = platform.packageConfig,
         version = platform.version,
         stdinSupportsAnsi = platform.stdinSupportsAnsi,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,4 +7,4 @@ dev_dependencies:
   test: ^1.0.0
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,5 @@
 name: platform
-version: 2.2.1
-authors:
-- Todd Volkert <tvolkert@google.com>
+version: 3.0.0-nullsafety
 description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 
@@ -9,4 +7,4 @@ dev_dependencies:
   test: ^1.0.0
 
 environment:
-  sdk: '>=1.24.0-dev.0.0 <3.0.0'
+  sdk: '>=2.8.0 <3.0.0'

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -18,7 +18,7 @@ void _expectPlatformsEqual(Platform actual, Platform expected) {
   expect(actual.resolvedExecutable, expected.resolvedExecutable);
   expect(actual.script, expected.script);
   expect(actual.executableArguments, expected.executableArguments);
-  expect(actual.packageRoot, expected.packageRoot);
+  expect(actual.packageRoot, expected.packageRoot); // ignore: deprecated_member_use_from_same_package
   expect(actual.packageConfig, expected.packageConfig);
   expect(actual.version, expected.version);
   expect(actual.localeName, expected.localeName);

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -18,7 +18,8 @@ void _expectPlatformsEqual(Platform actual, Platform expected) {
   expect(actual.resolvedExecutable, expected.resolvedExecutable);
   expect(actual.script, expected.script);
   expect(actual.executableArguments, expected.executableArguments);
-  expect(actual.packageRoot,
+  expect(
+      actual.packageRoot, // ignore: deprecated_member_use_from_same_package
       expected.packageRoot); // ignore: deprecated_member_use_from_same_package
   expect(actual.packageConfig, expected.packageConfig);
   expect(actual.version, expected.version);

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -89,4 +89,21 @@ void main() {
       });
     });
   });
+
+  test('Throws when unset non-null values are read', () {
+    final FakePlatform platform = FakePlatform();
+
+    expect(() => platform.numberOfProcessors, throwsA(isStateError));
+    expect(() => platform.pathSeparator, throwsA(isStateError));
+    expect(() => platform.operatingSystem, throwsA(isStateError));
+    expect(() => platform.operatingSystemVersion, throwsA(isStateError));
+    expect(() => platform.localHostname, throwsA(isStateError));
+    expect(() => platform.environment, throwsA(isStateError));
+    expect(() => platform.executable, throwsA(isStateError));
+    expect(() => platform.resolvedExecutable, throwsA(isStateError));
+    expect(() => platform.script, throwsA(isStateError));
+    expect(() => platform.executableArguments, throwsA(isStateError));
+    expect(() => platform.version, throwsA(isStateError));
+    expect(() => platform.localeName, throwsA(isStateError));
+  });
 }

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -18,7 +18,8 @@ void _expectPlatformsEqual(Platform actual, Platform expected) {
   expect(actual.resolvedExecutable, expected.resolvedExecutable);
   expect(actual.script, expected.script);
   expect(actual.executableArguments, expected.executableArguments);
-  expect(actual.packageRoot, expected.packageRoot); // ignore: deprecated_member_use_from_same_package
+  expect(actual.packageRoot,
+      expected.packageRoot); // ignore: deprecated_member_use_from_same_package
   expect(actual.packageConfig, expected.packageConfig);
   expect(actual.version, expected.version);
   expect(actual.localeName, expected.localeName);


### PR DESCRIPTION
Migrate platform to null-safety. Remove stable travis shard since that does not support null safety