### PR TITLE
publishable null-safety release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.0.0-nullsafety
+### 3.0.0-nullsafety.1
 
 * Migrate package to null-safe dart.
 

--- a/dev/travis.sh
+++ b/dev/travis.sh
@@ -27,4 +27,4 @@ echo "PASSED"
 set -e
 
 # Run the tests.
-pub run --enable-experiment=non-nullable test
+pub run test

--- a/lib/platform.dart
+++ b/lib/platform.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
+// @dart = 2.10
+
 /// Core interfaces & classes.
 export 'src/interface/local_platform.dart';
 export 'src/interface/platform.dart';

--- a/lib/platform.dart
+++ b/lib/platform.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.10
-
 /// Core interfaces & classes.
 export 'src/interface/local_platform.dart';
 export 'src/interface/platform.dart';

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
+// @dart = 2.10
 import 'dart:io' as io show Platform, stdin, stdout;
 
 import 'platform.dart';

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.10
 import 'dart:io' as io show Platform, stdin, stdout;
 
 import 'platform.dart';

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
+// @dart = 2.10
 import 'dart:convert';
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.10
 import 'dart:convert';
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.10
 import 'dart:convert';
 
 import '../interface/platform.dart';

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
+// @dart = 2.10
 import 'dart:convert';
 
 import '../interface/platform.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 
 dev_dependencies:
-  test: ^1.0.0
+  test: ^1.16.0-nullsafety.1
 
 environment:
-  sdk: '>=2.9.0 <3.0.0'
+  sdk: '>=2.10.0-4.0.dev <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,4 +7,4 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.1
 
 environment:
-  sdk: '>=2.10.0-4.0.dev <3.0.0'
+  sdk: '>=2.10.0-4.0.dev <2.10.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: platform
-version: 3.0.0-nullsafety
+version: 3.0.0-nullsafety.1
 description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.10
 import 'dart:io' as io;
 
 import 'package:platform/platform.dart';
@@ -28,8 +29,8 @@ void _expectPlatformsEqual(Platform actual, Platform expected) {
 
 void main() {
   group('FakePlatform', () {
-    FakePlatform fake;
-    LocalPlatform local;
+    late FakePlatform fake;
+    late LocalPlatform local;
 
     setUp(() {
       fake = new FakePlatform();

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.10
 import 'dart:io' as io;
 
 import 'package:platform/platform.dart';


### PR DESCRIPTION
Update the min-SDK constraint for publication. Update tests to run with null-safety.