### PR TITLE
Add OS constants for use in switch statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.0.1
+
+* Added string constants for each of the supported platforms for use in switch
+  statements.
+
 ### 3.0.0
 
 * First stable null safe release.

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -13,33 +13,33 @@ abstract class Platform {
 
   /// A string constant to compare with [operatingSystem] to see if the platform
   /// is Linux.
-  /// 
+  ///
   /// Useful in case statements when switching on [operatingSystem].
-  /// 
+  ///
   /// To just check if the platform is Linux, use [isLinux].
   static const String linux = 'linux';
 
   /// A string constant to compare with [operatingSystem] to see if the platform
   /// is Windows.
-  /// 
+  ///
   /// Useful in case statements when switching on [operatingSystem].
-  /// 
+  ///
   /// To just check if the platform is Windows, use [isWindows].
   static const String windows = 'windows';
 
   /// A string constant to compare with [operatingSystem] to see if the platform
   /// is macOS.
-  /// 
+  ///
   /// Useful in case statements when switching on [operatingSystem].
-  /// 
+  ///
   /// To just check if the platform is macOS, use [isMacOS].
   static const String macOS = 'macos';
 
   /// A string constant to compare with [operatingSystem] to see if the platform
   /// is Android.
-  /// 
+  ///
   /// Useful in case statements when switching on [operatingSystem].
-  /// 
+  ///
   /// To just check if the platform is Android, use [isAndroid].
   static const String android = 'android';
 
@@ -53,11 +53,21 @@ abstract class Platform {
 
   /// A string constant to compare with [operatingSystem] to see if the platform
   /// is Fuchsia.
-  /// 
+  ///
   /// Useful in case statements when switching on [operatingSystem].
-  /// 
+  ///
   /// To just check if the platform is Fuchsia, use [isFuchsia].
   static const String fuchsia = 'fuchsia';
+
+  /// A list of the possible values that [operatingSystem] can return.
+  static const List<String> operatingSystemValues = <String>[
+    linux,
+    macOS,
+    windows,
+    android,
+    iOS,
+    fuchsia,
+  ];
 
   /// The number of processors of the machine.
   int get numberOfProcessors;
@@ -68,6 +78,11 @@ abstract class Platform {
 
   /// A string (`linux`, `macos`, `windows`, `android`, `ios`, or `fuchsia`)
   /// representing the operating system.
+  ///
+  /// The possible return values are available from [operatingSystemValues], and
+  /// there are constants for each of the platforms to use in switch statements
+  /// or conditionals (See [linux], [macOS], [windows], [android], [iOS], and
+  /// [fuchsia]).
   String get operatingSystem;
 
   /// A string representing the version of the operating system or platform.

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -11,6 +11,54 @@ abstract class Platform {
   /// Creates a new [Platform].
   const Platform();
 
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is Linux.
+  /// 
+  /// Useful in case statements when switching on [operatingSystem].
+  /// 
+  /// To just check if the platform is Linux, use [isLinux].
+  static const String linux = 'linux';
+
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is Windows.
+  /// 
+  /// Useful in case statements when switching on [operatingSystem].
+  /// 
+  /// To just check if the platform is Windows, use [isWindows].
+  static const String windows = 'windows';
+
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is macOS.
+  /// 
+  /// Useful in case statements when switching on [operatingSystem].
+  /// 
+  /// To just check if the platform is macOS, use [isMacOS].
+  static const String macOS = 'macos';
+
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is Android.
+  /// 
+  /// Useful in case statements when switching on [operatingSystem].
+  /// 
+  /// To just check if the platform is Android, use [isAndroid].
+  static const String android = 'android';
+
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is iOS.
+  ///
+  /// Useful in case statements when switching on [operatingSystem].
+  ///
+  /// To just check if the platform is iOS, use [isIOS].
+  static const String iOS = 'ios';
+
+  /// A string constant to compare with [operatingSystem] to see if the platform
+  /// is Fuchsia.
+  /// 
+  /// Useful in case statements when switching on [operatingSystem].
+  /// 
+  /// To just check if the platform is Fuchsia, use [isFuchsia].
+  static const String fuchsia = 'fuchsia';
+
   /// The number of processors of the machine.
   int get numberOfProcessors;
 
@@ -29,22 +77,22 @@ abstract class Platform {
   String get localHostname;
 
   /// True if the operating system is Linux.
-  bool get isLinux => (operatingSystem == "linux");
+  bool get isLinux => operatingSystem == linux;
 
   /// True if the operating system is OS X.
-  bool get isMacOS => (operatingSystem == "macos");
+  bool get isMacOS => operatingSystem == macOS;
 
   /// True if the operating system is Windows.
-  bool get isWindows => (operatingSystem == "windows");
+  bool get isWindows => operatingSystem == windows;
 
   /// True if the operating system is Android.
-  bool get isAndroid => (operatingSystem == "android");
+  bool get isAndroid => operatingSystem == android;
 
   /// True if the operating system is iOS.
-  bool get isIOS => (operatingSystem == "ios");
+  bool get isIOS => operatingSystem == iOS;
 
   /// True if the operating system is Fuchsia
-  bool get isFuchsia => (operatingSystem == "fuchsia");
+  bool get isFuchsia => operatingSystem == fuchsia;
 
   /// The environment for this process.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: platform
-version: 3.0.0
+version: 3.0.1
 description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 
@@ -7,4 +7,4 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.1
+  test: ^1.16.8


### PR DESCRIPTION
This adds constants for each of the platforms so that you can write:

```dart
switch (platform.operatingSystem) {
  case Platform.macOS:
	// ...
	break;
  case Platform.linux:
	// ...
	break;
  // ...
}
```

Instead of having to know what the exact case-sensitive strings are that are possible values for `operatingSystem`, you can now use these constants in conditionals, and you can access the list of possible values from `Platform.operatingSystemValues`.

Sure, they're still strings, but you can treat them a little more like enum values (without the switch statement validation, sadly).