### PR TITLE
Fix sdk version constraint to no longer be pre-release

### DIFF
--- a/dev/travis.sh
+++ b/dev/travis.sh
@@ -5,20 +5,30 @@
 
 # Make sure dartfmt is run on everything
 echo "Checking dart format..."
-needs_dartfmt="$(dart format --set-exit-if-changed --output=none lib test dev)"
+needs_dart_format="$(dart format --set-exit-if-changed --output=none lib test dev 2>&1)"
 if [[ $? != 0 ]]; then
   echo "FAILED"
-  echo "$needs_dartfmt"
+  echo "$needs_dart_format"
   exit 1
 fi
 echo "PASSED"
 
 # Make sure we pass the analyzer
 echo "Checking dartanalyzer..."
-fails_analyzer="$(find lib test dev -name "*.dart" | xargs dartanalyzer --options analysis_options.yaml)"
+fails_analyzer="$(find lib test dev -name "*.dart" --print0 | xargs -0 dartanalyzer --options analysis_options.yaml 2>&1)"
 if [[ "$fails_analyzer" == *"[error]"* ]]; then
   echo "FAILED"
   echo "$fails_analyzer"
+  exit 1
+fi
+echo "PASSED"
+
+# Make sure we could publish if we wanted to.
+echo "Checking publishing..."
+fails_publish="$(pub publish --dry-run 2>&1)"
+if [[ $? != 0 ]]; then
+  echo "FAILED"
+  echo "$fails_publish"
   exit 1
 fi
 echo "PASSED"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.16.8


### PR DESCRIPTION
## Description

Fixed the Dart SDK constraint to no longer be a pre-release constraint (i.e. 2.12.0 instead of 2.12.0-0).

Also, added a pre-commit publish check.