### PR TITLE
Remove package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.1.0
+
+* Removed `Platform.packageRoot`, which was already marked deprecated, and which
+  didn't work in Dart 2.
+
 ### 3.0.2
 
 * Added `FakePlatform.copyWith` function.

--- a/lib/src/interface/local_platform.dart
+++ b/lib/src/interface/local_platform.dart
@@ -42,9 +42,6 @@ class LocalPlatform extends Platform {
   List<String> get executableArguments => io.Platform.executableArguments;
 
   @override
-  String? get packageRoot => null;
-
-  @override
   String? get packageConfig => io.Platform.packageConfig;
 
   @override

--- a/lib/src/interface/platform.dart
+++ b/lib/src/interface/platform.dart
@@ -159,16 +159,6 @@ abstract class Platform {
   /// list containing the flags passed to the executable.
   List<String> get executableArguments;
 
-  /// Deprecated, do not use.
-  ///
-  /// This used to be the value of the `--package-root` flag passed to the
-  /// executable used to run the script in this isolate, but is no longer
-  /// supported in Dart 2.
-  ///
-  /// Always returns null.
-  @Deprecated('packages/ directory resolution is not supported in Dart 2.')
-  String? get packageRoot;
-
   /// The value of the `--packages` flag passed to the executable
   /// used to run the script in this isolate. This is the configuration which
   /// specifies how Dart packages are looked up.
@@ -205,8 +195,6 @@ abstract class Platform {
       'resolvedExecutable': resolvedExecutable,
       'script': script.toString(),
       'executableArguments': executableArguments,
-      'packageRoot':
-          packageRoot, // ignore: deprecated_member_use_from_same_package
       'packageConfig': packageConfig,
       'version': version,
       'stdinSupportsAnsi': stdinSupportsAnsi,

--- a/lib/src/testing/fake_platform.dart
+++ b/lib/src/testing/fake_platform.dart
@@ -24,7 +24,6 @@ class FakePlatform extends Platform {
     String? resolvedExecutable,
     Uri? script,
     List<String>? executableArguments,
-    this.packageRoot,
     this.packageConfig,
     String? version,
     bool? stdinSupportsAnsi,
@@ -58,8 +57,6 @@ class FakePlatform extends Platform {
         _resolvedExecutable = platform.resolvedExecutable,
         _script = platform.script,
         _executableArguments = List<String>.from(platform.executableArguments),
-        packageRoot = platform
-            .packageRoot, // ignore: deprecated_member_use_from_same_package
         packageConfig = platform.packageConfig,
         _version = platform.version,
         _stdinSupportsAnsi = platform.stdinSupportsAnsi,
@@ -84,7 +81,6 @@ class FakePlatform extends Platform {
       resolvedExecutable: map['resolvedExecutable'],
       script: Uri.parse(map['script']),
       executableArguments: map['executableArguments'].cast<String>(),
-      packageRoot: map['packageRoot'],
       packageConfig: map['packageConfig'],
       version: map['version'],
       stdinSupportsAnsi: map['stdinSupportsAnsi'],
@@ -105,7 +101,6 @@ class FakePlatform extends Platform {
     String? resolvedExecutable,
     Uri? script,
     List<String>? executableArguments,
-    String? packageRoot,
     String? packageConfig,
     String? version,
     bool? stdinSupportsAnsi,
@@ -124,7 +119,6 @@ class FakePlatform extends Platform {
       resolvedExecutable: resolvedExecutable ?? this.resolvedExecutable,
       script: script ?? this.script,
       executableArguments: executableArguments ?? this.executableArguments,
-      packageRoot: packageRoot ?? this.packageRoot,
       packageConfig: packageConfig ?? this.packageConfig,
       version: version ?? this.version,
       stdinSupportsAnsi: stdinSupportsAnsi ?? this.stdinSupportsAnsi,
@@ -172,9 +166,6 @@ class FakePlatform extends Platform {
   @override
   List<String> get executableArguments => _throwIfNull(_executableArguments);
   List<String>? _executableArguments;
-
-  @override
-  String? packageRoot;
 
   @override
   String? packageConfig;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: platform
-version: 3.0.2
+version: 3.1.0
 description: A pluggable, mockable platform abstraction for Dart.
 homepage: https://github.com/google/platform.dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
   lints: ^1.0.1

--- a/test/fake_platform_test.dart
+++ b/test/fake_platform_test.dart
@@ -18,9 +18,6 @@ void _expectPlatformsEqual(Platform actual, Platform expected) {
   expect(actual.resolvedExecutable, expected.resolvedExecutable);
   expect(actual.script, expected.script);
   expect(actual.executableArguments, expected.executableArguments);
-  expect(
-      actual.packageRoot, // ignore: deprecated_member_use_from_same_package
-      expected.packageRoot); // ignore: deprecated_member_use_from_same_package
   expect(actual.packageConfig, expected.packageConfig);
   expect(actual.version, expected.version);
   expect(actual.localeName, expected.localeName);
@@ -78,8 +75,6 @@ void main() {
         expect(copy.resolvedExecutable, local.resolvedExecutable);
         expect(copy.script, local.script);
         expect(copy.executableArguments, local.executableArguments);
-        // ignore: deprecated_member_use_from_same_package
-        expect(copy.packageRoot, local.packageRoot);
         expect(copy.packageConfig, local.packageConfig);
         expect(copy.version, local.version);
         expect(copy.localeName, local.localeName);
@@ -112,7 +107,6 @@ void main() {
           resolvedExecutable: local.resolvedExecutable,
           script: local.script,
           executableArguments: local.executableArguments,
-          packageRoot: local.packageRoot,
           packageConfig: local.packageConfig,
           version: local.version,
           stdinSupportsAnsi: local.stdinSupportsAnsi,
@@ -140,7 +134,6 @@ void main() {
         expect(fake.resolvedExecutable, '/bin/dart');
         expect(fake.script, Uri.file('/platform/test/fake_platform_test.dart'));
         expect(fake.executableArguments, <String>['--checked']);
-        expect(fake.packageRoot, null);
         expect(fake.packageConfig, null);
         expect(fake.version, '1.22.0');
         expect(fake.localeName, 'de/de');

--- a/test/platform.json
+++ b/test/platform.json
@@ -14,7 +14,6 @@
   "executableArguments": [
     "--checked"
   ],
-  "packageRoot": null,
   "packageConfig": null,
   "version": "1.22.0",
   "localeName": "de/de"


### PR DESCRIPTION
Removes the `Platform.packageRoot`, which was already marked deprecated (https://github.com/dart-lang/sdk/issues/41197), and which doesn't work in Dart 2.

This is currently a blocker for https://github.com/dart-lang/sdk/issues/47769